### PR TITLE
Ability to set new validator and $validator fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Form validation for Vue.js 1.0+. Works along side `v-model` but can also be used
 Available through npm as `vue-form`.
 
 ``` js
-// es6: import * as vueForm from 'vue-form'; 
+// es6: import * as vueForm from 'vue-form';
 var vueForm = require('vue-form');
 Vue.use(vueForm);
 ```
-  
+
 You can also directly include it with a `<script>` tag when you have Vue itself included globally. It will automatically install itself.
 
 ### Usage
 
 This plugin registers two global directives, `v-form` and `v-form-ctrl`.  Apply the `v-form` directive to a `form` element, and set the `name` attribute. This `name` will hold the overall form state object and is created on the current vm.
 
-Apply the `v-form-ctrl` directive to each of the form inputs. `v-form-ctrl` will watch `v-model` and validate on change. Use static or binding attributes to specify validators (`required`, `maxlength`, `type="email"`, `type="url"`, etc)
+Apply the `v-form-ctrl` directive to each of the form inputs, and set the `name` or `id` attribute. `v-form-ctrl` will watch `v-model` and validate on change. Use static or binding attributes to specify validators (`required`, `maxlength`, `type="email"`, `type="url"`, etc).
 
 ```html
 <form v-form name="myform" @submit.prevent="onSubmit">
@@ -34,7 +34,7 @@ Apply the `v-form-ctrl` directive to each of the form inputs. `v-form-ctrl` will
 	</label>
 	<label>
 		<span>Email</span>
-		<input v-model="model.email" v-form-ctrl name="email" type="email" />
+		<input v-model="model.email" v-form-ctrl id="email" type="email" />
 	</label>
 	<button type="submit">Submit</button>
 </form>
@@ -59,6 +59,10 @@ Apply the `v-form-ctrl` directive to each of the form inputs. `v-form-ctrl` will
       "$invalid": true,
       "$error": {
         "required": true
+      },
+      "$validator": {},
+      "$validatorAttr": {
+        "required": true
       }
     }
   },
@@ -70,6 +74,10 @@ Apply the `v-form-ctrl` directive to each of the form inputs. `v-form-ctrl` will
     "$invalid": true,
     "$error": {
       "required": true
+    },
+    "$validator": {},
+    "$validatorAttr": {
+      "required": true
     }
   },
   "email": {
@@ -78,10 +86,24 @@ Apply the `v-form-ctrl` directive to each of the form inputs. `v-form-ctrl` will
     "$pristine": true,
     "$valid": true,
     "$invalid": false,
-    "$error": {}
+    "$error": {},
+    "$validator": {},
+    "$validatorAttr": {
+      "type": "email"
+    }
   }
 }
 ```
+
+`$validator` field's value is an object that maps names of assigned validators to the corresponding validator functions.
+For the `name` input field above `$validator` field is like:
+```js
+{
+  "required": function() {...}
+}
+```
+
+`$validatorAttr` field's value is an object that contains attributes which are used to define validators for the input field.
 
 ### Validators
 
@@ -113,7 +135,7 @@ You can use static validation attributes or bindings. If it is a binding, the in
 
 #### State classes
 
-As form and input validation states change, state classes are added and removed
+As form and input validation states change, state classes are added and removed.
 
 Possible form classes:
 ```
@@ -127,6 +149,21 @@ vf-dirty, vf-pristine, vf-valid, vf-invalid
 // also for every validation error, a class will be added, e.g.
 vf-invalid-required, vf-invalid-minlength, vf-invalid-max, etc
 ```
+
+#### Changing or adding validator
+
+It is possible to redefine a built-in validator or add a new one by using `vueForm.setValidator(name, validator)`. For example:
+```js
+vueForm.setValidator('url', function(value) {
+    return /^(https?\:\/\/)?.{4,}$/i.test(value);
+}).setValidator('integer', function(value) {
+    return /^\-?\d+$/.test(value);
+});
+```
+
+Added validator can be used as custom validator.
+
+`vueForm.getValidator(name)` returns validator function for the given name.
 
 #### Custom validator:
 
@@ -145,10 +182,12 @@ methods: {
 // ...
 ```
 
+Custom validator can be defined as method of the current vm or as global validator that is set via `vueForm.setValidator`.
+
 
 ### Custom form control component
 
-You can also use `vue-form` on your own form components. Simply wrap your component with an element with `v-form-ctrl`, `name` and any validation attributes. Set `v-form-ctrl` to the same property you will be updating via two-way binding in your component. You can also get a hook into the internals of `v-form-ctrl` to mange control state. 
+You can also use `vue-form` on your own form components. Simply wrap your component with an element with `v-form-ctrl`, `name` and any validation attributes. Set `v-form-ctrl` to the same property you will be updating via two-way binding in your component. You can also get a hook into the internals of `v-form-ctrl` to mange control state.
 
 [See custom tinymce component validation example ](https://github.com/fergaldoyle/vue-form/tree/master/example)
 

--- a/example/index.html
+++ b/example/index.html
@@ -9,7 +9,7 @@
             display: block;
             margin-bottom: 1.5em;
         }
-        
+
         label > span {
             display: inline-block;
             width: 8em;
@@ -34,7 +34,7 @@
 
         <label>
             <span>Email *</span>
-            <input v-model="model.email" v-form-ctrl name="email" type="email" required />
+            <input v-model="model.email" v-form-ctrl id="email" type="email" required />
         </label>
 
         <label>
@@ -71,10 +71,10 @@
             data: {
                 myform: {},
                 model: {
-                    contactRequired: false              
+                    contactRequired: false
                 }
             },
-            methods: {     
+            methods: {
                 onSubmit: function () {
                     console.log(this.myform.$valid);
                 }

--- a/example/test.html
+++ b/example/test.html
@@ -9,7 +9,7 @@
             display: block;
             margin-bottom: 1.5em;
         }
-        
+
         label > span {
             display: inline-block;
             width: 8em;
@@ -21,56 +21,60 @@
 <body>
 
     <form v-form name="myform" @submit.prevent="onSubmit" hook="formHook">
-        
+
         <div class="errors" v-if="myform.$submitted">
             <p v-if="myform.name.$error.required">Name is required.</p>
             <p v-if="myform.email.$error.email">Email is not valid.</p>
-        </div>      
+        </div>
             <label>
             <span>Email</span>
             <input v-model="model.email" v-form-ctrl name="email" type="email" required />
         </label>
-        
+
         <input v-model="model.j" v-form-ctrl name="j" type="number" :min="10" required />
-        <input v-model="model.k" v-form-ctrl name="k" type="number" max="10" />    
-        
+        <input v-model="model.k" v-form-ctrl name="k" type="number" max="10" />
+
         <input v-model="model.a" v-form-ctrl name="a" custom-validator="customValidator" placeholder="a" />
         <input v-model="model.b" v-form-ctrl name="b" custom-validator="customValidator" placeholder="b" required />
         <input v-model="model.c" v-form-ctrl name="c" pattern="\w\w" placeholder="c" />
         <input v-model="model.d" v-form-ctrl name="d" pattern="\w\w" placeholder="d" required />
         <input v-model="model.e" v-form-ctrl name="e" type="email" placeholder="e" />
-        <input v-model="model.f" v-form-ctrl name="f" type="email" placeholder="f" required />   
-        
+        <input v-model="model.f" v-form-ctrl name="f" type="email" placeholder="f" required />
+
         <button type="submit">Submit</button>
-        
+
     </form>
 
     <pre>{{ myform | json }}</pre>
-    
+
     <form name="myForm" v-form>
-        <input v-form-ctrl v-model="foobar" name="foobar" placeholder="foobar" required />
+        <input v-form-ctrl v-model="foobar" name="foobar" placeholder="foobar" required max="100" custom-validator="integer" />
         <input v-form-ctrl v-model="foobar2" name="foobar2" placeholder="foobar2" />
         <input v-form-ctrl v-model="foobar3" name="foobar3" type="email"  placeholder="foobar3" required />
         <input v-form-ctrl v-model="foobar4" name="foobar4" minlength="2" placeholder="foobar4" />
-        <input v-form-ctrl v-model="foobar5" name="foobar5" type="number" min="1" placeholder="foobar5" />
+        <input v-form-ctrl v-model="foobar5" id="foobar5" type="number" min="1" placeholder="foobar5" />
         <button type="submit">Submit</button>
     <pre>{{myForm | json }}</pre>
-    </form>    
+    </form>
 
     <script src="../node_modules/vue/dist/vue.js"></script>
     <script src="../vue-form.js"></script>
 
     <script>
+        vueForm.setValidator('integer', function(value) {
+            return /^\-?\d+$/.test(value);
+        });
+
         var vm = new Vue({
             el: 'body',
             data: {
                 myform: {},
                 model: {
                     contactRequired: false ,
-                 //   email: 'dfdf'            
+                 //   email: 'dfdf'
                 }
             },
-            methods: {     
+            methods: {
                 onSubmit: function () {
                     console.log(this.myform.$valid);
                 },
@@ -90,14 +94,14 @@
                 }, 200);
             }
         });
-        
+
         window.setPristine = function () {
-            vm.form.setPristine(); 
+            vm.form.setPristine();
         }
-   
+
         window.setUntouched = function () {
-            vm.form.setUntouched();  
-        }       
+            vm.form.setUntouched();
+        }
     </script>
 
 </body>


### PR DESCRIPTION
Hello,

I have made the following changes:
- Ability to change built-in or add new validator.
- New fields in state object: `$validator` and `$validatorAttr`.
- Ability to use input's `id` attribute for naming.
