### PR TITLE
Enable min/max validators to parse date fields

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -35,16 +35,16 @@ export const validators = {
     const patternRegExp = new RegExp('^' + pattern + '$');
     return patternRegExp.test(value);
   },
-  min(value, min) {
-    if (isNaN(min)) {
-      return value >= min;
+  min(value, min, vnode) {
+    if (vnode.data.attrs.type.toLowerCase() == 'number') {
+      return +value >= +min;
     }
-    return value * 1 >= min * 1;
+    return value >= min;
   },
   max(value, max, vnode) {
-    if (isNaN(max)) {
-      return max >= value;
+    if (vnode.data.attrs.type.toLowerCase() == 'number') {
+      return +max >= +value;
     }
-    return max * 1 >= value * 1;
+    return max >= value;
   }
 };

--- a/src/validators.js
+++ b/src/validators.js
@@ -36,9 +36,15 @@ export const validators = {
     return patternRegExp.test(value);
   },
   min(value, min) {
+    if (isNaN(min)) {
+      return value >= min;
+    }
     return value * 1 >= min * 1;
   },
-  max(value, max) {
+  max(value, max, vnode) {
+    if (isNaN(max)) {
+      return max >= value;
+    }
     return max * 1 >= value * 1;
   }
 };


### PR DESCRIPTION
The min/max validators have been overloaded to work with the following field types:

- datetime
- date
- week
- month

These field types accept string values which are always string comparable, e.g. '0100-W20' < '1000-W11' for type week.

I've opted into simply checking whether min/max is parsable as a number instead of inspecting the vnode to see if the type of input is `number` for simplicity.