### PR TITLE
Fix field component error when input has no attrs

### DIFF
--- a/src/components/field.js
+++ b/src/components/field.js
@@ -10,7 +10,7 @@ export default {
     };
     if (vModelnodes.length) {
       if(this.autoLabel) {
-        const id = vModelnodes[0].data.attrs.id || 'vf' + randomId();
+        const id = (vModelnodes[0].data.attrs && vModelnodes[0].data.attrs.id) || 'vf' + randomId();
         vModelnodes[0].data.attrs.id = id;
         if(foundVnodes.label) {
           foundVnodes.label.data = foundVnodes.label.data || {};


### PR DESCRIPTION
This fixes an error that arises from accessing an undefined attrs object in the following scenario:

    <field>
      <label>Name</label>
      <input v-model="name" />
    </field>

An easy workaround is for the user to add a `type` attribute to their input, but it is not a required attribute to have on an input.  This fix is not needed necessarily on the validate component since it should always have the `name` attribute present.