### PR TITLE
Fix a bug when using symbols in iOS 8.1

### DIFF
--- a/src/providers.js
+++ b/src/providers.js
@@ -1,5 +1,4 @@
 import { randomId } from './util';
 
-const s = typeof Symbol === 'function';
-export const vueFormConfig = s ? Symbol() : `VueFormProviderConfig${randomId}`;
-export const vueFormState =  s ? Symbol() : `VueFormProviderState${randomId}`;
+export const vueFormConfig = `VueFormProviderConfig${randomId()}`;
+export const vueFormState = `VueFormProviderState${randomId()}`;


### PR DESCRIPTION
For some reason, injecting objects with symbols as keys in Vue won’t work in iOS 8.1. To replicate this, simply create a <vue-form> and run it in the on iOS 8.1 or the iOS 8.1 simulator.

Also, the `randomId` function is now properly called