### PR TITLE
Add repository param to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vue-form",
   "version": "4.9.0",
   "description": "Form validation for Vue.js",
+  "repository": "github:fergaldoyle/vue-form",
   "main": "dist/vue-form.js",
   "scripts": {
     "dev": "rollup -w -c",


### PR DESCRIPTION
It would be great to be able to go directly to this repository from [npm package page](https://www.npmjs.com/package/vue-form), since it's not that easy to find this repo in Google typing just `vue-form`.