### PR TITLE
Update shallowObjectDiff

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -123,9 +123,7 @@ export function debounce(func, wait, immediate) {
 };
 
 export function isShallowObjectDifferent(a, b) {
-  let aValue = '';
-  let bValue = '';
-  Object.keys(a).sort().filter(v => typeof a[v] !== 'function').forEach(v => aValue += a[v]);
-  Object.keys(b).sort().filter(v => typeof a[v] !== 'function').forEach(v => bValue += b[v]);
+  let aValue = Object.keys(a).sort().map(k => typeof a[k] !== 'function' ? a[k] : k).reduce((result, v) => `${result}-${v}`);
+  let bValue = Object.keys(b).sort().map(k => typeof b[k] !== 'function' ? b[k] : k).reduce((result, v) => `${result}-${v}`);
   return aValue !== bValue;
 }


### PR DESCRIPTION
When changing custom validations, adding/removing functions will not trigger a re-calculation of the validators.
I modified the shallowObjectDiff method to also take into account the addition/removal of new functions, instead of just plainly ignoring them.

This is a breaking issue for me at this time.